### PR TITLE
Add GitHub Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you’ve found a security vulnerability in Kandji’s service, please notify us; we will work with you to resolve the issue promptly.
+
+Our full Responsible Disclosure Policy can be found here: 
+
+https://www.kandji.io/security


### PR DESCRIPTION
## Proposed Change
This does nothing but add a structured Security Policy to the GitHub repository. It has no functional impact on the codebase.

This is, verbatim, the same policy used for [kandji-inc/support](https://github.com/kandji-inc/support/blob/main/SECURITY.md)

## Benefit
Adding the security policy as a `SECURITY.md` at the root of the repository will make it indexible by GitHub - enabling the **Security Policy** option under the **Security** tab, and any expanded functionality GitHub introduces based on it. This metadata is also picked up by sources like Snyk Advisor.
![image](https://github.com/corda/corda-runtime-os/assets/34169713/f37c35b6-853a-4599-9333-07b7e0d4f999)