### PR TITLE
Addressing caching bug for multiple downloads, updating docstring

### DIFF
--- a/codebase/autopkg_tools.py
+++ b/codebase/autopkg_tools.py
@@ -148,7 +148,7 @@ RECIPE_TO_RUN = os.environ.get("RECIPE", None)
 
 def _run_command(shell_cmd):
     """Function accepts argument of shell command as `shell_cmd`
-    Returns shell output formatted as list"""
+    Returns shell stderr + stdout and shell cmd exit code"""
     raw_out = run(shell_cmd, stdout=PIPE, stderr=STDOUT, shell=True, check=True)
     decoded_out = raw_out.stdout.decode().strip()
     exit_code = raw_out.returncode

--- a/example-recipes/CacheRecipeMetadata/CacheRecipeMetadata.py
+++ b/example-recipes/CacheRecipeMetadata/CacheRecipeMetadata.py
@@ -67,7 +67,6 @@ __all__ = ["CacheRecipeMetadata"]
 def _run_command(shell_cmd):
     """Function accepts argument of shell command as `shell_cmd`
     Returns shell stderr + stdout and shell cmd exit code"""
-    shell_cmd = shell_cmd.split()
     raw_out = run(shell_cmd, stdout=PIPE, stderr=STDOUT, shell=True, check=False)
     decoded_out = raw_out.stdout.decode().strip()
     exit_code = raw_out.returncode


### PR DESCRIPTION
- Remediating `subprocess` method under `CacheRecipeMetadata.py` processor
  - Removing an errant `shell_cmd.split()` when attempting to handle multiple downloads for a recipe run
    - This method originally set `shell=False` when interpreting shell commands for execution, so required args in a `list`
- Updating docstring in `autopkg_tools.py` to reflect accurate statement of what's returned from `_run_command` func